### PR TITLE
Bug fix for Twisted client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,4 @@ setup(name=PKG,
       install_requires=['httplib2>=0.6.0', 'oauth2>=1.1.3', 'simplejson>=2.0.9'],
       keywords="simplegeo",
       zip_safe = True,
-      tests_require=['nose', 'coverage', 'python-geohash>=0.2'])
+      tests_require=['nose', 'coverage', 'python-geohash>=0.2', 'mock'])

--- a/simplegeo/__init__.py
+++ b/simplegeo/__init__.py
@@ -155,7 +155,7 @@ class Client(object):
             raise Exception("Record has no layer.")
 
         endpoint = self.endpoint('record', layer=record.layer, id=record.id)
-        self._request(endpoint, "PUT", record.to_json())
+        return self._request(endpoint, "PUT", record.to_json())
 
     def add_records(self, layer, records):
         features = {
@@ -163,11 +163,11 @@ class Client(object):
             'features': [record.to_dict() for record in records],
         }
         endpoint = self.endpoint('add_records', layer=layer)
-        self._request(endpoint, "POST", json.dumps(features))
+        return self._request(endpoint, "POST", json.dumps(features))
 
     def delete_record(self, layer, id):
         endpoint = self.endpoint('record', layer=layer, id=id)
-        self._request(endpoint, "DELETE")
+        return self._request(endpoint, "DELETE")
 
     def get_record(self, layer, id):
         endpoint = self.endpoint('record', layer=layer, id=id)

--- a/simplegeo/__init__.py
+++ b/simplegeo/__init__.py
@@ -157,6 +157,7 @@ class Client(object):
         'density_hour': 'density/%(day)s/%(hour)s/%(lat)s,%(lon)s.json',
         'layer': 'layer/%(layer)s.json',
         'new_layer': 'layers/%(layer)s.json',
+        'layers': 'layers.json',
         'contains' : 'contains/%(lat)s,%(lon)s.json',
         'overlaps' : 'overlaps/%(south)s,%(west)s,%(north)s,%(east)s.json',
         'boundary' : 'boundary/%(id)s.json',    
@@ -242,6 +243,10 @@ class Client(object):
 
     def get_layer(self, layer):
         endpoint = self.endpoint('layer', layer=layer)
+        return self._request(endpoint, "GET")
+
+    def get_layers(self):
+        endpoint = self.endpoint('layers')
         return self._request(endpoint, "GET")
 
     def create_layer(self, layer):

--- a/simplegeo/__init__.py
+++ b/simplegeo/__init__.py
@@ -4,6 +4,7 @@ import oauth2 as oauth
 import simplejson as json
 from httplib2 import Http
 from urlparse import urljoin
+from simplegeo.models import Layer
 
 __version__ = "unknown"
 try:
@@ -201,6 +202,10 @@ class Client(object):
     def get_layer(self, layer):
         endpoint = self.endpoint('layer', layer=layer)
         return self._request(endpoint, "GET")
+
+    def create_layer(self, layer):
+        endpoint = self.endpoint('layer', layer=layer.name)
+        return self._request(endpoint, "PUT", layer.to_json())
 
     def get_density(self, lat, lon, day, hour=None):
         if hour is not None:

--- a/simplegeo/twisted/client.py
+++ b/simplegeo/twisted/client.py
@@ -57,8 +57,10 @@ class Client(simplegeo.Client):
             code = str(response.code)
             message = body
             if isinstance(body, dict):
-                code = body['code']
-                message = body['message']
+                if 'code' in body:
+                    code = body['code']
+                if 'message' in body:
+                    message = body['message']
 
             raise simplegeo.APIError(code, message, response.headers)
 

--- a/tests/twisted/test_client.py
+++ b/tests/twisted/test_client.py
@@ -1,0 +1,55 @@
+import mock
+from twisted.trial import unittest
+from twisted.internet import defer, reactor
+from simplegeo import Record, APIError
+from simplegeo.twisted import Client
+
+MY_OAUTH_KEY = 'MY_OAUTH_KEY'
+MY_OAUTH_SECRET = 'MY_SECRET_KEY'
+TESTING_LAYER = 'TESTING_LAYER'
+
+API_VERSION = '0.1'
+API_HOST = 'api.simplegeo.com'
+API_PORT = 80
+
+class ClientTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = Client(MY_OAUTH_KEY, MY_OAUTH_SECRET, API_VERSION, API_HOST, API_PORT)
+
+    def fake_request(self, *args, **kwargs):
+        d = defer.Deferred()
+        reactor.callLater(0, d.callback, mock.sentinel.retval)
+        return d
+    
+    @defer.inlineCallbacks
+    def test_add_record_returns_deferred(self):
+        self.client._request = mock.Mock(wraps=self.fake_request)
+        record = Record(layer=TESTING_LAYER, id=69, lat=34.5, lon=-122.8)
+        deferred = self.client.add_record(record)
+        self.assertTrue(isinstance(deferred, defer.Deferred))
+        retval = yield deferred
+        self.assertEquals(mock.sentinel.retval, retval)
+
+    @defer.inlineCallbacks
+    def test_add_records_returns_deferred(self):
+        self.client._request = mock.Mock(wraps=self.fake_request)
+        records = [Record(layer=TESTING_LAYER, id=69, lat=34.5, lon=-122.8), Record(layer=TESTING_LAYER, id=70, lat=34.5, lon=-122.8)]
+        deferred = self.client.add_records(TESTING_LAYER, records)
+        self.assertTrue(isinstance(deferred, defer.Deferred))
+        retval = yield deferred
+        self.assertEquals(mock.sentinel.retval, retval)
+
+    @defer.inlineCallbacks
+    def test_delete_record_returns_deferred(self):
+        self.client._request = mock.Mock(wraps=self.fake_request)
+        deferred = self.client.delete_record(TESTING_LAYER, 4)
+        self.assertTrue(isinstance(deferred, defer.Deferred))
+        retval = yield deferred
+        self.assertEquals(mock.sentinel.retval, retval)
+        
+if __name__ == '__main__':
+    import sys
+    from twisted.scripts import trial
+    sys.argv.extend([sys.argv[0]])
+    trial.run()


### PR DESCRIPTION
Currently, for the add_record, add_records, and delete_record methods, the Twisted client does not return a Deferred object which means that there is no way for the client to know when the request finished or if an error occurred.  This patch includes unit tests.
