### PR TITLE
SSL with tests

### DIFF
--- a/simplegeo/__init__.py
+++ b/simplegeo/__init__.py
@@ -38,6 +38,7 @@ class Client(object):
         self.signature = oauth.SignatureMethod_HMAC_SHA1()
         self.uri = "http://%s:%s" % (host, port)
         self.headers = None
+        self.https = https
 
         self.subclient = getattr(self, 'subclient', False)
 
@@ -126,7 +127,7 @@ class Client(object):
         headers = request.to_header(self.realm)
         headers['User-Agent'] = 'SimpleGeo Python Client v%s' % __version__
 
-        self.headers, content = https.do_request(endpoint, method, body=body, headers=headers)
+        self.headers, content = self.https.request(endpoint, method, body=body, headers=headers)
 
         if self.headers['status'][0] not in ('2', '3'):
             raise APIError(int(self.headers['status']), content, self.headers)

--- a/simplegeo/__init__.py
+++ b/simplegeo/__init__.py
@@ -8,6 +8,7 @@ from pyutil import jsonutil as json
 
 from simplegeo.models import Feature
 from simplegeo.util import json_decode, APIError, SIMPLEGEOHANDLE_RSTR, is_simplegeohandle, to_unicode
+from simplegeo import https
 
 # For backwards compatibility with other codebases.
 from simplegeo.util import APIError, DecodeError
@@ -20,7 +21,7 @@ API_VERSION = '1.0'
 
 class Client(object):
 
-    realm = "http://api.simplegeo.com"
+    realm = "https://api.simplegeo.com"
     endpoints = {
         # Shared
         'feature': '1.0/features/%(simplegeohandle)s.json',
@@ -36,7 +37,6 @@ class Client(object):
         self.secret = secret
         self.signature = oauth.SignatureMethod_HMAC_SHA1()
         self.uri = "http://%s:%s" % (host, port)
-        self.http = Http()
         self.headers = None
 
         self.subclient = getattr(self, 'subclient', False)
@@ -126,7 +126,7 @@ class Client(object):
         headers = request.to_header(self.realm)
         headers['User-Agent'] = 'SimpleGeo Python Client v%s' % __version__
 
-        self.headers, content = self.http.request(endpoint, method, body=body, headers=headers)
+        self.headers, content = https.do_request(endpoint, method, body=body, headers=headers)
 
         if self.headers['status'][0] not in ('2', '3'):
             raise APIError(int(self.headers['status']), content, self.headers)

--- a/simplegeo/contrib/socks.py
+++ b/simplegeo/contrib/socks.py
@@ -1,0 +1,387 @@
+"""SocksiPy - Python SOCKS module.
+Version 1.00
+
+Copyright 2006 Dan-Haim. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of Dan Haim nor the names of his contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+   
+THIS SOFTWARE IS PROVIDED BY DAN HAIM "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL DAN HAIM OR HIS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMANGE.
+
+
+This module provides a standard socket-like interface for Python
+for tunneling connections through SOCKS proxies.
+
+"""
+
+import socket
+import struct
+
+PROXY_TYPE_SOCKS4 = 1
+PROXY_TYPE_SOCKS5 = 2
+PROXY_TYPE_HTTP = 3
+
+_defaultproxy = None
+_orgsocket = socket.socket
+
+class ProxyError(Exception):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+class GeneralProxyError(ProxyError):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+class Socks5AuthError(ProxyError):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+class Socks5Error(ProxyError):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+class Socks4Error(ProxyError):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+class HTTPError(ProxyError):
+	def __init__(self, value):
+		self.value = value
+	def __str__(self):
+		return repr(self.value)
+
+_generalerrors = ("success",
+		   "invalid data",
+		   "not connected",
+		   "not available",
+		   "bad proxy type",
+		   "bad input")
+
+_socks5errors = ("succeeded",
+		  "general SOCKS server failure",
+		  "connection not allowed by ruleset",
+		  "Network unreachable",
+		  "Host unreachable",
+		  "Connection refused",
+		  "TTL expired",
+		  "Command not supported",
+		  "Address type not supported",
+		  "Unknown error")
+
+_socks5autherrors = ("succeeded",
+		      "authentication is required",
+		      "all offered authentication methods were rejected",
+		      "unknown username or invalid password",
+		      "unknown error")
+
+_socks4errors = ("request granted",
+		  "request rejected or failed",
+		  "request rejected because SOCKS server cannot connect to identd on the client",
+		  "request rejected because the client program and identd report different user-ids",
+		  "unknown error")
+
+def setdefaultproxy(proxytype=None,addr=None,port=None,rdns=True,username=None,password=None):
+	"""setdefaultproxy(proxytype, addr[, port[, rdns[, username[, password]]]])
+	Sets a default proxy which all further socksocket objects will use,
+	unless explicitly changed.
+	"""
+	global _defaultproxy
+	_defaultproxy = (proxytype,addr,port,rdns,username,password)
+	
+class socksocket(socket.socket):
+	"""socksocket([family[, type[, proto]]]) -> socket object
+	
+	Open a SOCKS enabled socket. The parameters are the same as
+	those of the standard socket init. In order for SOCKS to work,
+	you must specify family=AF_INET, type=SOCK_STREAM and proto=0.
+	"""
+	
+	def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
+		_orgsocket.__init__(self,family,type,proto,_sock)
+		if _defaultproxy != None:
+			self.__proxy = _defaultproxy
+		else:
+			self.__proxy = (None, None, None, None, None, None)
+		self.__proxysockname = None
+		self.__proxypeername = None
+	
+	def __recvall(self, bytes):
+		"""__recvall(bytes) -> data
+		Receive EXACTLY the number of bytes requested from the socket.
+		Blocks until the required number of bytes have been received.
+		"""
+		data = ""
+		while len(data) < bytes:
+			data = data + self.recv(bytes-len(data))
+		return data
+	
+	def setproxy(self,proxytype=None,addr=None,port=None,rdns=True,username=None,password=None):
+		"""setproxy(proxytype, addr[, port[, rdns[, username[, password]]]])
+		Sets the proxy to be used.
+		proxytype -	The type of the proxy to be used. Three types
+				are supported: PROXY_TYPE_SOCKS4 (including socks4a),
+				PROXY_TYPE_SOCKS5 and PROXY_TYPE_HTTP
+		addr -		The address of the server (IP or DNS).
+		port -		The port of the server. Defaults to 1080 for SOCKS
+				servers and 8080 for HTTP proxy servers.
+		rdns -		Should DNS queries be preformed on the remote side
+				(rather than the local side). The default is True.
+				Note: This has no effect with SOCKS4 servers.
+		username -	Username to authenticate with to the server.
+				The default is no authentication.
+		password -	Password to authenticate with to the server.
+				Only relevant when username is also provided.
+		"""
+		self.__proxy = (proxytype,addr,port,rdns,username,password)
+	
+	def __negotiatesocks5(self,destaddr,destport):
+		"""__negotiatesocks5(self,destaddr,destport)
+		Negotiates a connection through a SOCKS5 server.
+		"""
+		# First we'll send the authentication packages we support.
+		if (self.__proxy[4]!=None) and (self.__proxy[5]!=None):
+			# The username/password details were supplied to the
+			# setproxy method so we support the USERNAME/PASSWORD
+			# authentication (in addition to the standard none).
+			self.sendall("\x05\x02\x00\x02")
+		else:
+			# No username/password were entered, therefore we
+			# only support connections with no authentication.
+			self.sendall("\x05\x01\x00")
+		# We'll receive the server's response to determine which
+		# method was selected
+		chosenauth = self.__recvall(2)
+		if chosenauth[0] != "\x05":
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		# Check the chosen authentication method
+		if chosenauth[1] == "\x00":
+			# No authentication is required
+			pass
+		elif chosenauth[1] == "\x02":
+			# Okay, we need to perform a basic username/password
+			# authentication.
+			self.sendall("\x01" + chr(len(self.__proxy[4])) + self.__proxy[4] + chr(len(self.proxy[5])) + self.__proxy[5])
+			authstat = self.__recvall(2)
+			if authstat[0] != "\x01":
+				# Bad response
+				self.close()
+				raise GeneralProxyError((1,_generalerrors[1]))
+			if authstat[1] != "\x00":
+				# Authentication failed
+				self.close()
+				raise Socks5AuthError,((3,_socks5autherrors[3]))
+			# Authentication succeeded
+		else:
+			# Reaching here is always bad
+			self.close()
+			if chosenauth[1] == "\xFF":
+				raise Socks5AuthError((2,_socks5autherrors[2]))
+			else:
+				raise GeneralProxyError((1,_generalerrors[1]))
+		# Now we can request the actual connection
+		req = "\x05\x01\x00"
+		# If the given destination address is an IP address, we'll
+		# use the IPv4 address request even if remote resolving was specified.
+		try:
+			ipaddr = socket.inet_aton(destaddr)
+			req = req + "\x01" + ipaddr
+		except socket.error:
+			# Well it's not an IP number,  so it's probably a DNS name.
+			if self.__proxy[3]==True:
+				# Resolve remotely
+				ipaddr = None
+				req = req + "\x03" + chr(len(destaddr)) + destaddr
+			else:
+				# Resolve locally
+				ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
+				req = req + "\x01" + ipaddr
+		req = req + struct.pack(">H",destport)
+		self.sendall(req)
+		# Get the response
+		resp = self.__recvall(4)
+		if resp[0] != "\x05":
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		elif resp[1] != "\x00":
+			# Connection failed
+			self.close()
+			if ord(resp[1])<=8:
+				raise Socks5Error(ord(resp[1]),_generalerrors[ord(resp[1])])
+			else:
+				raise Socks5Error(9,_generalerrors[9])
+		# Get the bound address/port
+		elif resp[3] == "\x01":
+			boundaddr = self.__recvall(4)
+		elif resp[3] == "\x03":
+			resp = resp + self.recv(1)
+			boundaddr = self.__recvall(resp[4])
+		else:
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		boundport = struct.unpack(">H",self.__recvall(2))[0]
+		self.__proxysockname = (boundaddr,boundport)
+		if ipaddr != None:
+			self.__proxypeername = (socket.inet_ntoa(ipaddr),destport)
+		else:
+			self.__proxypeername = (destaddr,destport)
+	
+	def getproxysockname(self):
+		"""getsockname() -> address info
+		Returns the bound IP address and port number at the proxy.
+		"""
+		return self.__proxysockname
+	
+	def getproxypeername(self):
+		"""getproxypeername() -> address info
+		Returns the IP and port number of the proxy.
+		"""
+		return _orgsocket.getpeername(self)
+	
+	def getpeername(self):
+		"""getpeername() -> address info
+		Returns the IP address and port number of the destination
+		machine (note: getproxypeername returns the proxy)
+		"""
+		return self.__proxypeername
+	
+	def __negotiatesocks4(self,destaddr,destport):
+		"""__negotiatesocks4(self,destaddr,destport)
+		Negotiates a connection through a SOCKS4 server.
+		"""
+		# Check if the destination address provided is an IP address
+		rmtrslv = False
+		try:
+			ipaddr = socket.inet_aton(destaddr)
+		except socket.error:
+			# It's a DNS name. Check where it should be resolved.
+			if self.__proxy[3]==True:
+				ipaddr = "\x00\x00\x00\x01"
+				rmtrslv = True
+			else:
+				ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
+		# Construct the request packet
+		req = "\x04\x01" + struct.pack(">H",destport) + ipaddr
+		# The username parameter is considered userid for SOCKS4
+		if self.__proxy[4] != None:
+			req = req + self.__proxy[4]
+		req = req + "\x00"
+		# DNS name if remote resolving is required
+		# NOTE: This is actually an extension to the SOCKS4 protocol
+		# called SOCKS4A and may not be supported in all cases.
+		if rmtrslv==True:
+			req = req + destaddr + "\x00"
+		self.sendall(req)
+		# Get the response from the server
+		resp = self.__recvall(8)
+		if resp[0] != "\x00":
+			# Bad data
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		if resp[1] != "\x5A":
+			# Server returned an error
+			self.close()
+			if ord(resp[1]) in (91,92,93):
+				self.close()
+				raise Socks4Error((ord(resp[1]),_socks4errors[ord(resp[1])-90]))
+			else:
+				raise Socks4Error((94,_socks4errors[4]))
+		# Get the bound address/port
+		self.__proxysockname = (socket.inet_ntoa(resp[4:]),struct.unpack(">H",resp[2:4])[0])
+		if rmtrslv != None:
+			self.__proxypeername = (socket.inet_ntoa(ipaddr),destport)
+		else:
+			self.__proxypeername = (destaddr,destport)
+	
+	def __negotiatehttp(self,destaddr,destport):
+		"""__negotiatehttp(self,destaddr,destport)
+		Negotiates a connection through an HTTP server.
+		"""
+		# If we need to resolve locally, we do this now
+		if self.__proxy[3] == False:
+			addr = socket.gethostbyname(destaddr)
+		else:
+			addr = destaddr
+		self.sendall("CONNECT " + addr + ":" + str(destport) + " HTTP/1.1\r\n" + "Host: " + destaddr + "\r\n\r\n")
+		# We read the response until we get the string "\r\n\r\n"
+		resp = self.recv(1)
+		while resp.find("\r\n\r\n")==-1:
+			resp = resp + self.recv(1)
+		# We just need the first line to check if the connection
+		# was successful
+		statusline = resp.splitlines()[0].split(" ",2)
+		if statusline[0] not in ("HTTP/1.0","HTTP/1.1"):
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		try:
+			statuscode = int(statusline[1])
+		except ValueError:
+			self.close()
+			raise GeneralProxyError((1,_generalerrors[1]))
+		if statuscode != 200:
+			self.close()
+			raise HTTPError((statuscode,statusline[2]))
+		self.__proxysockname = ("0.0.0.0",0)
+		self.__proxypeername = (addr,destport)
+	
+	def connect(self,destpair):
+		"""connect(self,despair)
+		Connects to the specified destination through a proxy.
+		destpar - A tuple of the IP/DNS address and the port number.
+		(identical to socket's connect).
+		To select the proxy server use setproxy().
+		"""
+		# Do a minimal input check first
+		if (type(destpair) in (list,tuple)==False) or (len(destpair)<2) or (type(destpair[0])!=str) or (type(destpair[1])!=int):
+			raise GeneralProxyError((5,_generalerrors[5]))
+		if self.__proxy[0] == PROXY_TYPE_SOCKS5:
+			if self.__proxy[2] != None:
+				portnum = self.__proxy[2]
+			else:
+				portnum = 1080
+			_orgsocket.connect(self,(self.__proxy[1],portnum))
+			self.__negotiatesocks5(destpair[0],destpair[1])
+		elif self.__proxy[0] == PROXY_TYPE_SOCKS4:
+			if self.__proxy[2] != None:
+				portnum = self.__proxy[2]
+			else:
+				portnum = 1080
+			_orgsocket.connect(self,(self.__proxy[1],portnum))
+			self.__negotiatesocks4(destpair[0],destpair[1])
+		elif self.__proxy[0] == PROXY_TYPE_HTTP:
+			if self.__proxy[2] != None:
+				portnum = self.__proxy[2]
+			else:
+				portnum = 8080
+			_orgsocket.connect(self,(self.__proxy[1],portnum))
+			self.__negotiatehttp(destpair[0],destpair[1])
+		elif self.__proxy[0] == None:
+			_orgsocket.connect(self,(destpair[0],destpair[1]))
+		else:
+			raise GeneralProxyError((4,_generalerrors[4]))

--- a/simplegeo/https.py
+++ b/simplegeo/https.py
@@ -1,0 +1,83 @@
+import ssl
+import socket
+from httplib2 import has_timeout
+import httplib2
+from simplegeo.contrib import socks
+
+
+class CertificateValidationError(httplib2.HttpLib2Error):
+    pass
+
+
+def validating_sever_factory():
+    # we need to define a closure here because we don't control
+    # the arguments this class is instantiated with
+    class ValidatingHTTPSConnection(httplib2.HTTPSConnectionWithTimeout):
+
+        def connect(self):
+            # begin copypasta from HTTPSConnectionWithTimeout
+            "Connect to a host on a given (SSL) port."
+
+            if self.proxy_info and self.proxy_info.isgood():
+                sock = socks.socksocket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.setproxy(*self.proxy_info.astuple())
+            else:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+            if has_timeout(self.timeout):
+                sock.settimeout(self.timeout)
+            sock.connect((self.host, self.port))
+            # end copypasta
+
+
+            try:
+                self.sock = ssl.wrap_socket(sock,
+                            self.key_file,
+                            self.cert_file,
+                            cert_reqs=ssl.CERT_REQUIRED
+                            )
+            except ssl.SSLError:
+                # we have to capture the exception here and raise later because
+                # httplib2 tries to ignore exceptions on connect
+                import sys
+                self._exc_info = sys.exc_info()
+                raise
+            else:
+                self._exc_info = None
+
+                # this might be redundant
+                server_cert = self.sock.getpeercert()
+                if not server_cert:
+                    raise CertificateValidationError(repr(server_cert))
+
+        def getresponse(self):
+            if not self._exc_info:
+                return httplib2.HTTPSConnectionWithTimeout.getresponse(self)
+            else:
+                raise self._exc_info[1], None, self._exc_info[2]
+    return ValidatingHTTPSConnection
+
+
+def request(url,
+        method='GET',
+        body=None,
+        headers=None,
+        keyfile=None,
+        certfile=None,
+        ca_certs=None,
+        proxy_info=None,
+        timeout=30):
+    """
+    makes an http/https request, with optional client certificate and server
+    certificate verification.
+    returns response, content
+    """
+    kwargs = {}
+    h = httplib2.Http(proxy_info=proxy_info, timeout=timeout)
+    is_ssl = url.startswith('https')
+    if is_ssl and ca_certs:
+        kwargs['connection_type'] = validating_sever_factory()
+
+    if is_ssl and keyfile and certfile:
+        h.add_certificate(keyfile, certfile, '')
+    return h.request(url, method=method, body=body, headers=headers, **kwargs)

--- a/simplegeo/test/client/test_client.py
+++ b/simplegeo/test/client/test_client.py
@@ -107,60 +107,60 @@ class ClientTest(unittest.TestCase):
         h = self.client.get_most_recent_http_headers()
         self.failUnlessEqual(h, None)
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', 'thingie': "just to see if you're listening"}, EXAMPLE_POINT_BODY)
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', 'thingie': "just to see if you're listening"}, EXAMPLE_POINT_BODY)
+        self.client.https = mockhttps
 
         self.client.get_feature("SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970")
         h = self.client.get_most_recent_http_headers()
         self.failUnlessEqual(h, {'status': '200', 'content-type': 'application/json', 'thingie': "just to see if you're listening"})
 
     def test_get_point_feature(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', 'thingie': "just to see if you're listening"}, EXAMPLE_POINT_BODY)
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', 'thingie': "just to see if you're listening"}, EXAMPLE_POINT_BODY)
+        self.client.https = mockhttps
 
         res = self.client.get_feature("SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970")
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
         # the code under test is required to have json-decoded this before handing it back
         self.failUnless(isinstance(res, Feature), (repr(res), type(res)))
 
     def test_get_polygon_feature(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.https = mockhttps
 
         res = self.client.get_feature("SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970")
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
 
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
         # the code under test is required to have json-decoded this before handing it back
         self.failUnless(isinstance(res, Feature), (repr(res), type(res)))
 
     def test_get_feature_bad_json(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY + 'some crap')
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY + 'some crap')
+        self.client.https = mockhttps
 
         try:
             self.client.get_feature("SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970")
         except DecodeError, e:
             self.failUnlessEqual(e.code, None, repr(e.code))
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_dont_json_decode_results(self):
         """ _request() is required to return the exact string that the HTTP
         server sent to it -- no transforming it, such as by json-decoding. """
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, '{ "Hello": "I am a string. \xe2\x9d\xa4" }'.decode('utf-8'))
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, '{ "Hello": "I am a string. \xe2\x9d\xa4" }'.decode('utf-8'))
+        self.client.https = mockhttps
         res = self.client._request("http://thing", 'POST')[1]
         self.failUnlessEqual(res, '{ "Hello": "I am a string. \xe2\x9d\xa4" }'.decode('utf-8'))
 
@@ -171,26 +171,27 @@ class ClientTest(unittest.TestCase):
 
         EXAMPLE_RECORD_JSONSTR=json.dumps({ 'geometry' : { 'type' : 'Point', 'coordinates' : [D('10.0'), D('11.0')] }, 'id' : 'my_id', 'type' : 'Feature', 'properties' : { 'key' : 'value'  , 'type' : 'object' } })
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_RECORD_JSONSTR)
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_RECORD_JSONSTR)
+        self.client.https = mockhttps
         res = self.client._request("http://thing", 'POST')[1]
         self.failUnlessEqual(res, EXAMPLE_RECORD_JSONSTR)
 
     def test_get_feature_error(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
-        self.client.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
+        self.client.https = mockhttps
 
         try:
             self.client.get_feature("SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970")
         except APIError, e:
+            print repr(e)
             self.failUnlessEqual(e.code, 500, repr(e.code))
             self.failUnlessEqual(e.msg, '{"message": "help my web server is confuzzled"}', (type(e.msg), repr(e.msg)))
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, "SG_4bgzicKFmP89tQFGLGZYy0_34.714646_-86.584970"))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_APIError(self):
         e = APIError(500, 'whee', {'status': "500"})
@@ -214,16 +215,16 @@ class TestAnnotations(unittest.TestCase):
         self.handle = 'SG_4H2GqJDZrc0ZAjKGR8qM4D'
 
     def test_get_annotations(self):
-        mockhttp = mock.Mock()
+        mockhttps = mock.Mock()
         headers = {'status': '200', 'content-type': 'application/json'}
-        mockhttp.request.return_value = (headers, json.dumps(EXAMPLE_ANNOTATIONS_RESPONSE))
-        self.client.http = mockhttp
+        mockhttps.request.return_value = (headers, json.dumps(EXAMPLE_ANNOTATIONS_RESPONSE))
+        self.client.https = mockhttps
 
         res = self.client.get_annotations(self.handle)
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s/annotations.json' % (API_VERSION, self.handle))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s/annotations.json' % (API_VERSION, self.handle))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
         # Make sure client returns a dict.
         self.failUnless(isinstance(res, dict))
@@ -237,16 +238,16 @@ class TestAnnotations(unittest.TestCase):
             self.fail('Should have raised exception.')
 
     def test_annotate(self):
-        mockhttp = mock.Mock()
+        mockhttps = mock.Mock()
         headers = {'status': '200', 'content-type': 'application/json'}
-        mockhttp.request.return_value = (headers, json.dumps(EXAMPLE_ANNOTATE_RESPONSE))
-        self.client.http = mockhttp
+        mockhttps.request.return_value = (headers, json.dumps(EXAMPLE_ANNOTATE_RESPONSE))
+        self.client.https = mockhttps
 
         res = self.client.annotate(self.handle, EXAMPLE_ANNOTATIONS, True)
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s/annotations.json' % (API_VERSION, self.handle))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'POST')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s/annotations.json' % (API_VERSION, self.handle))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'POST')
 
         # Make sure client returns a dict.
         self.failUnless(isinstance(res, dict))

--- a/simplegeo/test/client/test_context.py
+++ b/simplegeo/test/client/test_context.py
@@ -43,14 +43,14 @@ class ContextTest(unittest.TestCase):
         self.assertRaises(Exception, self.client._endpoint, 'context')
 
     def test_get_context(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         res = self.client.context.get_context(self.query_lat, self.query_lon)
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
         # the code under test is required to have json-decoded this before handing it back
         self.failUnless(isinstance(res, dict), (type(res), repr(res)))
 
@@ -60,76 +60,76 @@ class ContextTest(unittest.TestCase):
         mock_make_nonce.return_value = 5
         mock_make_timestamp.return_value = 6
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         self.client.context.get_context(self.query_lat, self.query_lon)
 
-        self.assertEqual(mockhttp.method_calls[0][2]['body'], None)
-        self.assertEqual(mockhttp.method_calls[0][2]['headers']['Authorization'], 'OAuth realm="http://api.simplegeo.com", oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_nonce="5", oauth_timestamp="6", oauth_consumer_key="MY_OAUTH_KEY", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="aCYUTCHSeVlAQiu0CmG2tF71I74%3D"')
+        self.assertEqual(mockhttps.method_calls[0][2]['body'], None)
+        self.assertEqual(mockhttps.method_calls[0][2]['headers']['Authorization'], 'OAuth realm="https://api.simplegeo.com", oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_nonce="5", oauth_timestamp="6", oauth_consumer_key="MY_OAUTH_KEY", oauth_signature_method="HMAC-SHA1", oauth_version="1.0", oauth_signature="aCYUTCHSeVlAQiu0CmG2tF71I74%3D"')
 
     def test_get_context_by_address(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         addr = '41 Decatur St, San Francisco, CA'
         self.client.context.get_context_by_address(addr)
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/address.json?address=%s' % (API_VERSION, urllib.quote_plus(addr)))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/address.json?address=%s' % (API_VERSION, urllib.quote_plus(addr)))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_get_context_by_my_ip(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         self.client.context.get_context_by_my_ip()
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/ip.json' % (API_VERSION,))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/ip.json' % (API_VERSION,))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_get_context_by_ip(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         ipaddr = '192.0.32.10'
         self.client.context.get_context_by_ip(ipaddr=ipaddr)
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s.json' % (API_VERSION, ipaddr))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s.json' % (API_VERSION, ipaddr))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_get_context_by_ip_invalid(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         self.failUnlessRaises(AssertionError, self.client.context.get_context_by_ip, '40.1,127.999')
 
     def test_get_context_invalid(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY)
+        self.client.context.https = mockhttps
 
         self.failUnlessRaises(AssertionError, self.client.context.get_context, -91, 100)
         self.failUnlessRaises(AssertionError, self.client.context.get_context, -11, 361)
 
     def test_get_context_no_body(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, None)
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, None)
+        self.client.context.https = mockhttps
 
         self.failUnlessRaises(DecodeError, self.client.context.get_context, self.query_lat, self.query_lon)
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_get_context_bad_json(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY + 'some crap')
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_BODY + 'some crap')
+        self.client.context.https = mockhttps
 
         try:
             self.client.context.get_context(self.query_lat, self.query_lon)
@@ -138,14 +138,14 @@ class ContextTest(unittest.TestCase):
             self.failUnless("Could not decode" in e.msg, repr(e.msg))
             repr(e)
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_get_context_error(self):
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
-        self.client.context.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
+        self.client.context.https = mockhttps
 
         try:
             self.client.context.get_context(self.query_lat, self.query_lon)
@@ -153,9 +153,9 @@ class ContextTest(unittest.TestCase):
             self.failUnlessEqual(e.code, 500, repr(e.code))
             self.failUnlessEqual(e.msg, '{"message": "help my web server is confuzzled"}', (type(e.msg), repr(e.msg)))
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/context/%s,%s.json' % (API_VERSION, self.query_lat, self.query_lon))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_APIError(self):
         e = APIError(500, 'whee', {'status': "500"})

--- a/simplegeo/test/client/test_places.py
+++ b/simplegeo/test/client/test_places.py
@@ -54,7 +54,7 @@ class PlacesTest(unittest.TestCase):
             return ({'status': '202', 'content-type': 'application/json', 'location': newloc}, json.dumps({'id': handle}))
 
         mockhttp.request = mockrequest
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         feature = Feature(
             coordinates=(D('37.8016'), D('-122.4783'))
@@ -87,7 +87,7 @@ class PlacesTest(unittest.TestCase):
             return ({'status': '202', 'content-type': 'application/json', 'location': newloc}, json.dumps({'id': handle}))
 
         mockhttp.request = mockrequest
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         feature = Feature(
             coordinates=(D('37.8016'), D('-122.4783'))
@@ -117,7 +117,7 @@ class PlacesTest(unittest.TestCase):
             return ({'status': '202', 'content-type': 'application/json', 'location': newloc}, json.dumps({'id': handle}))
 
         mockhttp.request = mockrequest
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         feature = Feature(
             coordinates=(D('37.8016'), D('-122.4783'))
@@ -169,7 +169,7 @@ class PlacesTest(unittest.TestCase):
             return ({'status': '202', 'content-type': 'application/json', 'location': newloc}, json.dumps({'id': handle}))
 
         mockhttp.request = mockrequest
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         feature = Feature(
             properties={'record_id': record_id},
@@ -185,7 +185,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, resultfeature.to_json())
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         res = self.client.places.get_feature(handle)
         self.assertEqual(mockhttp.method_calls[0][0], 'request')
@@ -197,7 +197,7 @@ class PlacesTest(unittest.TestCase):
     def test_empty_body(self):
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, None)
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         self.client.places._request("http://anyrandomendpoint", 'POST')
 
@@ -209,7 +209,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, '{ "Hello": "I am a string. \xe2\x9d\xa4" }'.decode('utf-8'))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
         res = self.client.places._request("http://thing", 'POST')[1]
         self.failUnlessEqual(res, '{ "Hello": "I am a string. \xe2\x9d\xa4" }'.decode('utf-8'))
 
@@ -222,7 +222,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, EXAMPLE_RECORD_JSONSTR)
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
         res = self.client.places._request("http://thing", 'POST')[1]
         self.failUnlessEqual(res, EXAMPLE_RECORD_JSONSTR)
 
@@ -232,7 +232,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, {'token': "this is your polling token"})
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         res = self.client.places.update_feature(rec)
         self.failUnless(isinstance(res, dict), res)
@@ -254,7 +254,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, "whatever the response body is")
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         res = self.client.places.delete_feature(handle)
         self.failUnlessEqual(res, "whatever the response body is")
@@ -269,7 +269,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         self.failUnlessRaises(AssertionError, self.client.places.search, -91, 100)
         self.failUnlessRaises(AssertionError, self.client.places.search, -81, 361)
@@ -292,7 +292,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         self.failUnlessRaises(AssertionError, self.client.places.search, -91, 100)
         self.failUnlessRaises(AssertionError, self.client.places.search, -81, 361)
@@ -313,7 +313,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         self.failUnlessRaises(AssertionError, self.client.places.search_by_ip, 'this is not an IP address at all, silly')
         self.failUnlessRaises(AssertionError, self.client.places.search_by_ip, -81, 181) # Someone accidentally passed lat, lon to search_by_ip().
@@ -346,7 +346,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         self.failUnlessRaises(AssertionError, self.client.places.search_by_ip, 'this is not an IP address at all, silly')
         self.failUnlessRaises(AssertionError, self.client.places.search_by_ip, -81, 181) # Someone accidentally passed lat, lon to search_by_ip().
@@ -367,7 +367,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         self.failUnlessRaises(AssertionError, self.client.places.search_by_my_ip, ipaddr) # Someone accidentally passed an ip addr to search_by_my_ip().
@@ -398,7 +398,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         self.failUnlessRaises(AssertionError, self.client.places.search_by_my_ip, ipaddr) # Someone accidentally passed an ip addr to search_by_my_ip().
@@ -417,7 +417,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -453,7 +453,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -471,7 +471,7 @@ class PlacesTest(unittest.TestCase):
     def test_radius_search(self):
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': []}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -487,7 +487,7 @@ class PlacesTest(unittest.TestCase):
     def test_radius_search_by_ip(self):
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': []}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         radius = D('0.01')
@@ -502,7 +502,7 @@ class PlacesTest(unittest.TestCase):
     def test_radius_search_by_my_ip(self):
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': []}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         radius = D('0.01')
@@ -519,7 +519,7 @@ class PlacesTest(unittest.TestCase):
     def test_radius_search_by_address(self):
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': []}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -541,7 +541,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -559,7 +559,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         res = self.client.places.search_by_ip(ipaddr)
@@ -576,7 +576,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         ipaddr = '192.0.32.10'
         self.failUnlessRaises(AssertionError, self.client.places.search_by_my_ip, ipaddr) # Someone accidentally passed an ip addr to search_by_my_ip().
@@ -594,7 +594,7 @@ class PlacesTest(unittest.TestCase):
 
         mockhttp = mock.Mock()
         mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, json.dumps({'type': "FeatureColllection", 'features': [rec1.to_dict(), rec2.to_dict()]}))
-        self.client.places.http = mockhttp
+        self.client.places.https = mockhttp
 
         lat = D('11.03')
         lon = D('10.04')
@@ -612,9 +612,9 @@ class PlacesTest(unittest.TestCase):
     def test_get_feature_bad_json(self):
         handle = 'SG_abcdefghijklmnopqrstuv'
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '200', 'content-type': 'application/json', }, 'some crap')
-        self.client.places.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '200', 'content-type': 'application/json', }, 'some crap')
+        self.client.places.https = mockhttps
 
         try:
             self.client.places.get_feature(handle)
@@ -623,9 +623,9 @@ class PlacesTest(unittest.TestCase):
             self.failUnless("Could not decode JSON" in e.msg, repr(e.msg))
             repr(e)
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, handle))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, handle))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')
 
     def test_APIError(self):
         e = APIError(500, 'whee', {'status': "500"})
@@ -637,9 +637,9 @@ class PlacesTest(unittest.TestCase):
     def test_get_places_error(self):
         handle = 'SG_abcdefghijklmnopqrstuv'
 
-        mockhttp = mock.Mock()
-        mockhttp.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
-        self.client.places.http = mockhttp
+        mockhttps = mock.Mock()
+        mockhttps.request.return_value = ({'status': '500', 'content-type': 'application/json', }, '{"message": "help my web server is confuzzled"}')
+        self.client.places.https = mockhttps
 
         try:
             self.client.places.get_feature(handle)
@@ -647,6 +647,6 @@ class PlacesTest(unittest.TestCase):
             self.failUnlessEqual(e.code, 500, repr(e.code))
             self.failUnlessEqual(e.msg, '{"message": "help my web server is confuzzled"}', (type(e.msg), repr(e.msg)))
 
-        self.assertEqual(mockhttp.method_calls[0][0], 'request')
-        self.assertEqual(mockhttp.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, handle))
-        self.assertEqual(mockhttp.method_calls[0][1][1], 'GET')
+        self.assertEqual(mockhttps.method_calls[0][0], 'request')
+        self.assertEqual(mockhttps.method_calls[0][1][0], 'http://api.simplegeo.com:80/%s/features/%s.json' % (API_VERSION, handle))
+        self.assertEqual(mockhttps.method_calls[0][1][1], 'GET')


### PR DESCRIPTION
I used this approach: http://stackoverflow.com/questions/2363105/how-to-do-mutual-certificate-authentication-with-httplib2

...but in an attempt to use the OS's root CA certificates, I am NOT passing a ca_cert argument to ssl.wrap_socket.  I assume that this means the root certificate is used, but I'm not yet sure how to check.

```
self.sock = ssl.wrap_socket(sock,
                        self.key_file,
                        self.cert_file,
                        cert_reqs=ssl.CERT_REQUIRED,
                        ***ca_certs=ca_cert_file***
                        )
```

The socks library is unreliable from pip/easy_install/PyPI, and it's only 1 file, so I just included it in a contrib directory.

I also had a bit of a doozy fixing up the 45 broken tests because client.http was being mocked all over the place.  Learned how that worked and fixed it.
