### PR TITLE
The get_layers method wasn't accepting any kwargs

### DIFF
--- a/simplegeo/storage/__init__.py
+++ b/simplegeo/storage/__init__.py
@@ -83,6 +83,6 @@ class Client(ParentClient):
         endpoint = self._endpoint('layer', layer=name)
         return json_decode(self._request(endpoint, "GET")[1])
 
-    def get_layers(self):
+    def get_layers(self, **kwargs):
         endpoint = self._endpoint('layers')
-        return json_decode(self._request(endpoint, "GET")[1])
+        return json_decode(self._request(endpoint, "GET", data=kwargs)[1])


### PR DESCRIPTION
In listing the layers, the api endpoint accepts 2 parameters, limit and cursor https://simplegeo.com/docs/api-endpoints/simplegeo-storage#layer-management, for pagination, but the python client wasn't accepting any kwargs.

This update adds kwargs to the get_layers def.
